### PR TITLE
naive implementation

### DIFF
--- a/core/src/main/scala/aima/core/agent/Simulation.scala
+++ b/core/src/main/scala/aima/core/agent/Simulation.scala
@@ -1,0 +1,46 @@
+package aima.core.agent
+
+import aima.core.agent.Simulation._
+
+import scala.collection.immutable.Map
+
+/**
+  * @author Damien Favre
+  */
+final case class Simulation[ENVIRONMENT, PERCEPT, ACTION](
+    environment: ENVIRONMENT,
+    agents: List[Agent[ENVIRONMENT, PERCEPT, ACTION]],
+    performanceMeasure: PerformanceMeasure[ENVIRONMENT, PERCEPT, ACTION]
+) {
+  def run(): (Simulation[ENVIRONMENT, PERCEPT, ACTION], SimulationRunSummary[ENVIRONMENT, PERCEPT, ACTION]) = {
+    val (newEnv, simulationRunSummary) =
+      agents.foldLeft((environment, emptySimulationRunSummary[ENVIRONMENT, PERCEPT, ACTION])) {
+        case ((env, simulationRunSummary), agent) =>
+          val (newEnv, agentRunSummary) = agent.run(env)
+          val agentPerformance          = performanceMeasure(newEnv, agent)
+          val agentSimulationRunSummary: AgentSimulationRunSummary[ENVIRONMENT, PERCEPT, ACTION] =
+            AgentSimulationRunSummary(agentRunSummary, agentPerformance)
+          (newEnv, simulationRunSummary + (agent -> agentSimulationRunSummary))
+      }
+    (
+      Simulation(newEnv, agents, performanceMeasure),
+      simulationRunSummary
+    )
+  }
+
+}
+
+object Simulation {
+
+  type PerformanceMeasure[ENVIRONMENT, PERCEPT, ACTION] =
+    (ENVIRONMENT, Agent[ENVIRONMENT, PERCEPT, ACTION]) => Double
+  type SimulationRunSummary[ENVIRONMENT, PERCEPT, ACTION] =
+    Map[Agent[ENVIRONMENT, PERCEPT, ACTION], AgentSimulationRunSummary[ENVIRONMENT, PERCEPT, ACTION]]
+  def emptySimulationRunSummary[ENVIRONMENT, PERCEPT, ACTION]: SimulationRunSummary[ENVIRONMENT, PERCEPT, ACTION] =
+    Map.empty
+}
+
+final case class AgentSimulationRunSummary[ENVIRONMENT, PERCEPT, ACTION](
+    agentRunSummary: AgentRunSummary[PERCEPT, ACTION],
+    performance: Double
+)

--- a/core/src/main/scala/aima/core/environment/vacuum/PerformanceMeasure.scala
+++ b/core/src/main/scala/aima/core/environment/vacuum/PerformanceMeasure.scala
@@ -1,0 +1,11 @@
+package aima.core.environment.vacuum
+
+import aima.core.agent.Agent
+import aima.core.agent.Simulation.PerformanceMeasure
+
+object PerformanceMeasure {
+  //This measure only cares about the state of the vacuum world
+  val cleanliness: PerformanceMeasure[VacuumEnvironment, VacuumPercept, VacuumAction] =
+    (vacuumEnvironment: VacuumEnvironment, _: Agent[VacuumEnvironment, VacuumPercept, VacuumAction]) =>
+      vacuumEnvironment.map.nodes.collect(_.dirtStatus == CleanPercept).size
+}


### PR DESCRIPTION
This is a naive implementation of https://github.com/aimacode/aima-scala/issues/81 . I can see a few issues emerging principally around measuring performance based on the state of an agent.

If I take the vacuum world example, we will probably want a performance measure that take into account the number of actions performed by the vacuum cleaner. When moving or sucking, the vacuum cleaner consumes energy and hence we should somehow associate a state to the agent. The idea would be to be able to measure at each point in time, how much energy has been consumed by the agent and score the performance based on that.

The current Agent API has a run method that returns an updated environment but doesn't update the agent state. I am not sure what's the best way to handle it:

- override the run method when implementing the agent trait ?
- add a `STATE` type parameter to the agent trait. Update this state in the run method and return the updated agent alongside the updated environment. But then it feels that we could move the run method out of the agent altogether and put it in a `Simulation` trait/case class

